### PR TITLE
Add cross-compilation flags

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Build and extract bitcode from sqlite3 cross-compiling to CHERI
+# riscv64-purecap
+
+set -e
+
+if ! [ "$1" = "riscv64" ]; then
+	echo "Only riscv64 is supported."
+	# Exit gracefully because we do not want the build to fail
+	exit 0
+fi
+
+CHERI=$HOME/cheri/output/sdk
+CHERIBUILD=$HOME/build
+CC=$CHERI/bin/clang
+LLVM_COMPILER_PATH=$CHERI/bin
+GLLVM_OBJCOPY=$LLVM_COMPILER_PATH/objcopy
+SQLITE_DIR=$HOME/cheri/build/sqlite-riscv64-purecap-build
+
+go build -v ./...
+go install -v ./...
+GCLANG=$HOME/go/bin/gclang
+GET_BC=$HOME/go/bin/get-bc
+
+cd $CHERIBUILD
+python3 cheribuild.py sqlite-riscv64-purecap
+cd $SQLITE_DIR
+make clean
+sed -i "s|$CC|$GCLANG|g" Makefile
+LLVM_COMPILER_PATH=$LLVM_COMPILER_PATH GCLANG=$GCLANG GLLVM_OBJCOPY=$GLLVM_OBJCOPY make
+LLVM_COMPILER_PATH=$LLVM_COMPILER_PATH $GET_BC sqlite3

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help:
 install: develop
 
 develop:
-	go install github.com/SRI-CSL/gllvm/cmd/...
+	go install github.com/capablevms/gllvm/cmd/...
 
 
 check: develop

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,8 @@
+status = ["buildbot/capablevms-test-script"]
+
+timeout_sec = 7200 # 2h
+
+# Have bors delete auto-merged branches
+delete_merged_branches = true
+
+cut_body_after = ""

--- a/shared/parser.go
+++ b/shared/parser.go
@@ -163,12 +163,11 @@ func Parse(argList []string) ParserResult {
 	var argsExactMatches = map[string]flagInfo{
 
 		"/dev/null": {0, pr.inputFileCallback}, //iam: linux kernel
-
-		"-":  {0, pr.printOnlyCallback},
-		"-o": {1, pr.outputFileCallback},
-		"-c": {0, pr.compileOnlyCallback},
-		"-E": {0, pr.preprocessOnlyCallback},
-		"-S": {0, pr.assembleOnlyCallback},
+		"-":         {0, pr.printOnlyCallback},
+		"-o":        {1, pr.outputFileCallback},
+		"-c":        {0, pr.compileOnlyCallback},
+		"-E":        {0, pr.preprocessOnlyCallback},
+		"-S":        {0, pr.assembleOnlyCallback},
 
 		"--verbose": {0, pr.verboseFlagCallback},
 		"--param":   {1, pr.defaultBinaryCallback},
@@ -244,6 +243,8 @@ func Parse(argList []string) ParserResult {
 		"-mindirect-branch-register":   {0, pr.compileUnaryCallback}, //iam: linux kernel stuff
 
 		"-mllvm": {1, pr.compileBinaryCallback}, //iam: chromium
+
+		"-mno-relax": {0, pr.compileLinkUnaryCallback}, // CHERI
 
 		"-A": {1, pr.compileBinaryCallback},
 		"-D": {1, pr.compileBinaryCallback},
@@ -351,6 +352,7 @@ func Parse(argList []string) ParserResult {
 
 		"-Wl,-dead_strip": {0, pr.warningLinkUnaryCallback},
 		"-dead_strip":     {0, pr.warningLinkUnaryCallback}, //iam: tor does this. We lose the bitcode :-(
+		"-target":         {1, pr.compileLinkBinaryCallback}, // cross-compiling, e.g. CHERI
 	}
 
 	// iam: this is a list because matching needs to be done in order.
@@ -386,6 +388,7 @@ func Parse(argList []string) ParserResult {
 		{`^-mmacosx-version-min=.+$`, flagInfo{0, pr.compileLinkUnaryCallback}},
 		{`^-mstack-alignment=.+$`, flagInfo{0, pr.compileUnaryCallback}},          //iam, linux kernel stuff
 		{`^-march=.+$`, flagInfo{0, pr.compileUnaryCallback}},                     //iam: linux kernel stuff
+		{`^-mabi=.+$`, flagInfo{0, pr.compileLinkUnaryCallback}},                  // CHERI
 		{`^-mregparm=.+$`, flagInfo{0, pr.compileUnaryCallback}},                  //iam: linux kernel stuff
 		{`^-mcmodel=.+$`, flagInfo{0, pr.compileUnaryCallback}},                   //iam: linux kernel stuff
 		{`^-mpreferred-stack-boundary=.+$`, flagInfo{0, pr.compileUnaryCallback}}, //iam: linux kernel stuff

--- a/tests/parsing_test.go
+++ b/tests/parsing_test.go
@@ -15,6 +15,8 @@ const input2 = `-Wl,--fatal-warnings -Wl,--build-id=sha1 -fPIC -Wl,-z,noexecstac
 
 const input3 = `1.c 2.c 3.c 4.c 5.c -Wl,--start-group 7.o 8.o 9.o -Wl,--end-group 10.c 11.c 12.c 13.c`
 
+const input4 = `-target riscv64-unknown-freebsd13 --sysroot=/home/cheriworker/cheri/output/rootfs-riscv64-purecap -B/home/cheriworker/cheri/output/sdk/bin -march=rv64imafdcxcheri -mabi=l64pc128d -mno-relax`
+
 func plto(input string, t *testing.T) {
 	cmds := strings.Fields(input)
 	parsed := shared.Parse(cmds)
@@ -38,4 +40,5 @@ func Test_parsing(t *testing.T) {
 	plto(input1, t)
 	pl(input2, t, 32)
 	pl(input3, t, 5)
+	pl(input4, t, 6)
 }


### PR DESCRIPTION
Cross-compilation flags for CHERI. ~~There are no (automated) tests yet. Upstream uses github workflows but I haven't enabled any action yet.~~ Correct generation of bitcode is tested on sqlite3-riscv64-purecap.